### PR TITLE
Fix code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -121,11 +121,11 @@ def get_locations():
         # print(data)  # Print data to console
         return jsonify(data)
     except requests.HTTPError as http_err:
-        print(f"Locations: HTTP error occurred: {http_err}")
-        return jsonify({"error": str(http_err)}), 500
+        app.logger.error(f"Locations: HTTP error occurred: {http_err}")
+        return jsonify({"error": "An internal error has occurred."}), 500
     except Exception as err:
-        print(f"Locations: Other error occurred: {err}")
-        return jsonify({"error": str(err)}), 500
+        app.logger.error(f"Locations: Other error occurred: {err}")
+        return jsonify({"error": "An internal error has occurred."}), 500
 
 
 @app.route("/usersdevices")
@@ -142,11 +142,11 @@ def get_users_devices():
         # print(data)  # Print data to console
         return jsonify(data)
     except requests.HTTPError as http_err:
-        print(f"UsersAndDevices: HTTP error occurred: {http_err}")
-        return jsonify({"error": str(http_err)}), 500
+        app.logger.error(f"UsersAndDevices: HTTP error occurred: {http_err}")
+        return jsonify({"error": "An internal error has occurred."}), 500
     except Exception as err:
-        print(f"UsersAndDevices: Other error occurred: {err}")
-        return jsonify({"error": str(err)}), 500
+        app.logger.error(f"UsersAndDevices: Other error occurred: {err}")
+        return jsonify({"error": "An internal error has occurred."}), 500
 
 
 """Proxy all insecure requests to the insecure server


### PR DESCRIPTION
Fixes [https://github.com/Romano-Garmez/wherehaveibeen/security/code-scanning/5](https://github.com/Romano-Garmez/wherehaveibeen/security/code-scanning/5)

To fix the problem, we should avoid returning the string representation of the exception directly to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This approach ensures that sensitive information is not exposed while still allowing developers to debug issues using the server logs.

- Modify the exception handling blocks to log the detailed error message and return a generic error message to the user.
- Add necessary imports for logging if not already present.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
