### PR TITLE
Security hardening - remove custom OSRM router support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,8 +111,11 @@ Production is hosted on Fly.io using Docker (see `fly.toml` and `Dockerfile`).
 ### Session-Based Authentication
 
 **Security Model:**
-- Credentials stored in Flask encrypted session cookie (not in database)
-- Session encrypted with `WHIB_FLASK_SECRET_KEY` environment variable
+- Credentials stored in Flask session cookie (not in database)
+- The session is **signed** (tamper-proof) with `WHIB_FLASK_SECRET_KEY`, but
+  **not encrypted** — the cookie contents are base64-readable by anyone who
+  holds the cookie. The username/password are therefore exposed to the client.
+  The cookie is set `Secure` + `HttpOnly` + `SameSite=Lax` to limit exposure.
 - Session lifetime: 30 days (`app.permanent_session_lifetime`)
 - Sign-out clears entire session (`session.clear()`)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,7 @@ WORKDIR /app
 COPY --from=builder /app/.venv .venv/
 COPY . .
 EXPOSE 5000
-CMD ["/app/.venv/bin/flask", "run", "--host=0.0.0.0", "--port=5000"]
+# Run via app.py, which serves with Waitress (a production WSGI server) and
+# validates required env vars on startup. The Flask dev server (`flask run`) is
+# not suitable for production.
+CMD ["/app/.venv/bin/python", "app.py"]

--- a/app.py
+++ b/app.py
@@ -178,21 +178,18 @@ def save_settings():
     data = request.json
     # Retrieve user inputs from the form
     circle_size = data.get('circleSize')
-    osrm_url = data.get('osrmURL')
 
     session.permanent = True
 
     # Store information in the session
     session["circle_size"] = circle_size
-    session["osrm_url"] = osrm_url
 
     return jsonify({"message": "Settings saved successfully"})
-    
+
 @app.route("/get_settings")
 def get_settings():
     return jsonify({
-        "circleSize": session.get("circle_size"),
-        "osrmURL": session.get("osrm_url")
+        "circleSize": session.get("circle_size")
     })
 
 

--- a/app.py
+++ b/app.py
@@ -24,6 +24,16 @@ app = Flask(__name__)
 app.secret_key = os.getenv("WHIB_FLASK_SECRET_KEY")
 app.permanent_session_lifetime = timedelta(days=30)
 
+# The session cookie holds the user's OwnTracks credentials, so harden it:
+# - Secure: only sent over HTTPS (never leaks over a plain-HTTP request)
+# - HttpOnly: not readable from JavaScript (limits XSS credential theft)
+# - SameSite=Lax: not sent on cross-site POSTs, which blunts CSRF
+app.config.update(
+    SESSION_COOKIE_SECURE=True,
+    SESSION_COOKIE_HTTPONLY=True,
+    SESSION_COOKIE_SAMESITE="Lax",
+)
+
 DEFAULT_OSRM_URL = os.getenv("WHIB_DEFAULT_OSRM_URL")
 OWNTRACKS_URL = os.getenv("WHIB_OWNTRACKS_URL")
 
@@ -316,50 +326,41 @@ def get_users_devices():
         return jsonify({"error": INTERNAL_ERROR_MESSAGE}), 500
 
 
-"""Proxy all insecure requests to the insecure server
+"""Proxy routing requests to our OSRM server.
 
-Unfortunately, the insecure server does not support HTTPS. 
-This means that we cannot make requests to it from the 
-client browser without mixed content errors
-This route makes the server handle insecure requests so 
-we don't have to
+The OSRM server only speaks HTTP, so the browser can't call it directly from an
+HTTPS page (mixed-content). This route forwards the request server-side.
+
+The OSRM target is fixed to WHIB_DEFAULT_OSRM_URL — we deliberately do NOT accept
+a client-supplied target URL. Letting the client choose the URL turned this into
+an open SSRF proxy (any caller could make the server fetch arbitrary internal or
+external URLs). Custom OSRM routers are no longer supported.
 """
 
 
 @app.route("/proxy", methods=["GET"])
 def proxy_route():
-    print("Proxying request to insecure server")
+    # Require a valid session so this isn't an open, unauthenticated proxy.
+    if not session.get("username"):
+        return jsonify({"error": "Not logged in."}), 401
 
-    osrm_url = request.args.get('osrmURL')
-    coords = request.args.get('coords') 
+    coords = request.args.get("coords")
+    if not coords:
+        return jsonify({"error": "Missing coords parameter."}), 400
+    # The client prefixes coords with a leading separator char; strip it.
     coords = coords[1:]
 
-
-    #print("coords: ", coords)
-
-    target_url = ""
-    # Construct the URL you want to forward the request to
-    if osrm_url:
-        target_url = f"{osrm_url}/route/v1/{coords}"
-        #print("using custom osrm url")
-    else:
-        target_url = f"{DEFAULT_OSRM_URL}/route/v1/{coords}"
-        #print("using default osrm url")
-
+    target_url = f"{DEFAULT_OSRM_URL}/route/v1/{coords}"
     if target_url.endswith("?overview=false"):
         target_url = target_url.replace("?overview=false", "")
-    
-    
-    #print("target_url is ", target_url)
 
-    # Forward the request to the insecure server
-    response = requests.get(target_url)
-
-    #print("response status code: ", response.status_code)
-    #print("response content: ", response.content)
-
-    # Return the response back to the client
-    return jsonify(response.json())
+    try:
+        response = requests.get(target_url, timeout=30)
+        response.raise_for_status()
+        return jsonify(response.json())
+    except requests.RequestException as err:
+        app.logger.error(f"Proxy: Error contacting OSRM server: {err}")
+        return jsonify({"error": INTERNAL_ERROR_MESSAGE}), 502
 
 
 if __name__ == "__main__":

--- a/static/js/cacheManager.js
+++ b/static/js/cacheManager.js
@@ -413,21 +413,14 @@ function formatBytes(bytes) {
  * Validate that cached settings match current settings
  * @param {Object} cachedSettings - Settings stored with cache
  * @param {number} currentBufferSize - Current buffer size setting
- * @param {string} currentOsrmUrl - Current OSRM URL setting
  * @returns {boolean} True if settings match
  */
-function validateCacheSettings(cachedSettings, currentBufferSize, currentOsrmUrl) {
+function validateCacheSettings(cachedSettings, currentBufferSize) {
     if (!cachedSettings) return false;
 
     // Check if buffer size matches
     if (cachedSettings.bufferSize !== currentBufferSize) {
         console.log('Cache invalid: buffer size changed from', cachedSettings.bufferSize, 'to', currentBufferSize);
-        return false;
-    }
-
-    // Check if OSRM URL matches
-    if (cachedSettings.osrmUrl !== currentOsrmUrl) {
-        console.log('Cache invalid: OSRM URL changed');
         return false;
     }
 

--- a/static/js/drawOnMap.js
+++ b/static/js/drawOnMap.js
@@ -138,21 +138,9 @@ async function calculateComplexRoute(latlngs) {
     console.log("latlngs: ", latlngs);
     let start = Date.now();
 
-    let osrmRouter = "";
-    try {
-        osrmRouter = document.getElementById('osrmURL').value;
-    } catch (err) {
-        console.log("No custom OSRM router found, using default");
-    }
-
-    if (osrmRouter != "") {
-        console.log("Using custom OSRM router: " + osrmRouter);
-    } else {
-        console.log("Using default OSRM router");
-    }
-
-    // Construct the service URL
-    const serviceUrl = `/proxy?osrmURL=${encodeURIComponent(osrmRouter)}&coords=`;
+    // Custom OSRM routers are no longer supported — the server always uses its
+    // configured OSRM URL (see /proxy). We no longer send an osrmURL param.
+    const serviceUrl = `/proxy?coords=`;
 
     console.log("Service URL: ", serviceUrl);
 

--- a/static/js/logIn.js
+++ b/static/js/logIn.js
@@ -88,12 +88,8 @@ async function getUserSettings() {
 
         // load settings
 
-        //osrm url
-        let select = document.getElementById("osrmURL");
-        select.value = data.osrmURL;
-
         //buffer size
-        select = document.getElementById("circleSize");
+        let select = document.getElementById("circleSize");
         if (data.circleSize != null) {
             select.value = data.circleSize;
         } else {

--- a/templates/index.html
+++ b/templates/index.html
@@ -121,17 +121,6 @@
                 </svg>
             </span>
         </button>
-        <button type="button" class="mapControlBtn" onclick="clearCurrentCache()" title="Clear cache">
-            <span class="mapControlLabel">Clear Cache</span>
-            <span class="mapControlIcon">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <polyline points="3 6 5 6 21 6"></polyline>
-                    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
-                    <line x1="10" y1="11" x2="10" y2="17"></line>
-                    <line x1="14" y1="11" x2="14" y2="17"></line>
-                </svg>
-            </span>
-        </button>
         <button type="button" class="mapControlBtn" onclick="openSettingsPanel()" title="More settings">
             <span class="mapControlLabel">More</span>
             <span class="mapControlIcon">
@@ -157,7 +146,6 @@
                 <button class="btn btn-primary settings-nav-apply" id="applySettingsButton" onclick="resetMap(map)">Apply</button>
                 <button class="settings-nav-btn active" onclick="scrollToSetting('settingsMap')">Map</button>
                 <button class="settings-nav-btn" onclick="scrollToSetting('settingsCache')">Cache</button>
-                <button class="settings-nav-btn" onclick="scrollToSetting('settingsRouting')">Routing</button>
                 <button class="settings-nav-btn" onclick="scrollToSetting('settingsAccount')">Account</button>
             </nav>
             <div class="settingsPanelContent">
@@ -165,6 +153,16 @@
                     <h4>Map Settings</h4>
                     <p class="settingInfo">Adjust settings about the way the routes and blue area buffer are drawn on the
                         map.</p>
+                    <h5>View Mode <span class="info-icon">i
+                            <span class="tooltip-text">Switch between Routes (your travelled paths with a blue area
+                                buffer) and Heatmap (visitor frequency by location).</span>
+                        </span></h5>
+                    <p class="settingInfo">Choose how your location history is displayed.</p>
+                    <div class="btn-group" role="group" id="mapModeToggle">
+                        <input type="button" class="btn btn-secondary" value="Routes" onclick="setMapMode('routes')" />
+                        <input type="button" class="btn btn-secondary" value="Heatmap" onclick="setMapMode('heatmap')" />
+                    </div>
+
                     <h5>Hide Route <span class="info-icon">i
                             <span class="tooltip-text">The route is only drawn when less than 500 GPS
                                 points are used. Adjust the date filters to see this!</span>
@@ -305,6 +303,16 @@
         btn.title = mode === 'heatmap'
             ? 'View mode: Heatmap (tap to switch to Routes)'
             : 'View mode: Routes (tap to switch to Heatmap)';
+
+        // Reflect the active mode on the settings-panel toggle buttons
+        const toggle = document.getElementById('mapModeToggle');
+        if (toggle) {
+            toggle.querySelectorAll('input').forEach(b => {
+                const isActive = b.value.toLowerCase() === mode;
+                b.classList.toggle('btn-primary', isActive);
+                b.classList.toggle('btn-secondary', !isActive);
+            });
+        }
     }
 
     async function runTasks() {
@@ -1112,7 +1120,7 @@
         const content = document.querySelector('.settingsPanelContent');
         if (!content) return;
 
-        const sectionIds = ['settingsMap', 'settingsCache', 'settingsRouting', 'settingsAccount'];
+        const sectionIds = ['settingsMap', 'settingsCache', 'settingsAccount'];
 
         content.addEventListener('scroll', function() {
             const scrollTop = content.scrollTop;

--- a/templates/index.html
+++ b/templates/index.html
@@ -193,18 +193,6 @@
                     <input type="button" class="btn btn-warning" value="Clear Cache" onclick="clearCurrentCache()" />
                 </div>
 
-                <div class="subPanel" id="settingsRouting">
-                    <h4>Routing Settings</h4>
-                    <p class="settingInfo">Change the URL of the routing engine if you host your own or want to use the
-                        public OSRM one.</p>
-                    <h5>Custom OSRM Router <span class="info-icon">i
-                            <span class="tooltip-text">Change the URL used for the OSRM router. Changing this will invalidate your cache.</span>
-                        </span></h5>
-
-                    <p class="settingInfo">Default: leave blank</p>
-                    <input type="url" class="form-control form-control-lg" id="osrmURL" value="" />
-                </div>
-
                 <div class="subPanel" id="settingsAccount">
                     <h4>Account</h4>
                     <p class="settingInfo">Need help connecting OwnTracks to your account?</p>
@@ -276,8 +264,7 @@
      */
     function getCurrentSettings() {
         return {
-            bufferSize: parseFloat(document.getElementById('circleSize').value) || 0.5,
-            osrmUrl: document.getElementById('osrmURL').value || ''
+            bufferSize: parseFloat(document.getElementById('circleSize').value) || 0.5
         };
     }
 
@@ -355,8 +342,7 @@
                         // Then validate settings match
                         cacheValid = validateCacheSettings(
                             cacheData.settings,
-                            currentSettings.bufferSize,
-                            currentSettings.osrmUrl
+                            currentSettings.bufferSize
                         );
 
                         if (!cacheValid) {
@@ -1171,8 +1157,7 @@
                 'Content-Type': 'application/json'
             },
             body: JSON.stringify({
-                circleSize: document.getElementById('circleSize').value,
-                osrmURL: document.getElementById('osrmURL').value
+                circleSize: document.getElementById('circleSize').value
             })
         })
             .then(response => response.json())


### PR DESCRIPTION
Allowing users to enter their own server URL could be dubious from a security standpoint. Now that this app no longer expects you to host it yourself, hiding some of these settings for simplicity

